### PR TITLE
Commit after init wok

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,6 +124,13 @@ def test_031_start(data_dir: pathlib.Path, cooked_repo: pygit2.Repository) -> No
     assert cooked_repo.head.shorthand == 'branch-1'
 
 
+def test_032_start_with_empty_repo(
+    data_dir: pathlib.Path, empty_repo: pygit2.Repository
+) -> None:
+    with pytest.raises(ValueError, match='The workspace is not initialized'):
+        core.start(branch_name='branch-1')
+
+
 def test_041_join(
     data_dir: pathlib.Path, cooked_repo: pygit2.Repository, repo_1_path: pathlib.Path
 ) -> None:
@@ -242,6 +249,7 @@ def test_061_finish(
     )
     assert next(cooked_repo_walker).message == finish_message
     assert next(cooked_repo_walker).message == "Update `wok` config"
+    assert next(cooked_repo_walker).message == "Add `wok` config"
     assert next(cooked_repo_walker).message == "Initial commit"
 
     repo_1_walker = repo_1.walk(repo_1.head.target, pygit2.GIT_SORT_TOPOLOGICAL)

--- a/wok/core/cmd.py
+++ b/wok/core/cmd.py
@@ -15,13 +15,12 @@ def init(*, ctx: context.Context) -> None:
     if not ctx.root_repo.head_is_unborn:
         conf.ref = ctx.root_repo.head.shorthand
     conf.save()
+    commit(message="Add `wok` config")
 
 
 @context.with_context
-def commit(*, ctx: context.Context) -> None:
-    base.commit(
-        repo=ctx.root_repo, message="Update `wok` config", pathspecs=[ctx.conf_path]
-    )
+def commit(*, ctx: context.Context, message: str = "Update `wok` config") -> None:
+    base.commit(repo=ctx.root_repo, message=message, pathspecs=[ctx.conf_path])
 
 
 @context.with_context
@@ -48,6 +47,8 @@ def add(*, ctx: context.Context, path: pathlib.Path, url: str) -> None:
 
 @context.with_context
 def start(*, ctx: context.Context, branch_name: str) -> None:
+    if ctx.root_repo.head_is_unborn:
+        raise ValueError("The workspace is not initialized. Run `wok init`.")
     try:
         ref = ctx.root_repo.lookup_reference_dwim(branch_name)
     except KeyError:


### PR DESCRIPTION
Resolves #12.

Shouldn't `wok init` commit a new `wok.yml`? At least it fixes many issues with unborn repos.